### PR TITLE
feat(Modem): periodically send an empty line as a keep-alive

### DIFF
--- a/lib/tablespoon/intersection.ex
+++ b/lib/tablespoon/intersection.ex
@@ -189,7 +189,6 @@ defmodule Tablespoon.Intersection do
   end
 
   def handle_info(:reconnect, state) do
-    state = %{state | connected?: false}
     {:noreply, state, {:continue, :connect}}
   end
 

--- a/lib/tablespoon/intersection.ex
+++ b/lib/tablespoon/intersection.ex
@@ -155,7 +155,7 @@ defmodule Tablespoon.Intersection do
 
           state
 
-        {:error, _} = e ->
+        {:error, e} ->
           state = %{state | connect_failure_count: state.connect_failure_count + 1}
 
           _ =

--- a/lib/tablespoon/transport/fake_modem.ex
+++ b/lib/tablespoon/transport/fake_modem.ex
@@ -105,6 +105,10 @@ defmodule Tablespoon.Transport.FakeModem do
     handle_buffer(t)
   end
 
+  defp handle_line(t, "") do
+    handle_buffer(t)
+  end
+
   def trigger?(rate) do
     Enum.random(1..100) <= rate
   end

--- a/lib/tablespoon/transport/ssh.ex
+++ b/lib/tablespoon/transport/ssh.ex
@@ -90,6 +90,14 @@ defmodule Tablespoon.Transport.SSH do
 
   def stream(
         %__MODULE__{conn_ref: conn_ref, channel_id: channel_id} = ssh,
+        {:ssh_cm, conn_ref, {:exit_signal, channel_id, _signal, _error, _lang}}
+      ) do
+    # exit signal message: we don't do anything with this
+    {:ok, ssh, []}
+  end
+
+  def stream(
+        %__MODULE__{conn_ref: conn_ref, channel_id: channel_id} = ssh,
         {:ssh_cm, conn_ref, {:eof, channel_id}}
       ) do
     # the other side closed their write connection: nothing to do

--- a/semaphore/setup.sh
+++ b/semaphore/setup.sh
@@ -1,25 +1,22 @@
 #!/bin/bash
 set -e
-ELIXIR_VERSION=1.10
-ERLANG_VERSION=23.0
 
-export MIX_HOME=$SEMAPHORE_CACHE_DIR/mix
-mkdir -p $MIX_HOME
+export ASDF_DATA_DIR=$SEMAPHORE_CACHE_DIR/.asdf
 
-export ERL_HOME="${SEMAPHORE_CACHE_DIR}/.kerl/installs/${ERLANG_VERSION}"
-
-if [ ! -d "${ERL_HOME}" ]; then
-    mkdir -p "${ERL_HOME}"
-    KERL_BUILD_BACKEND=git kerl build $ERLANG_VERSION $ERLANG_VERSION
-    kerl install $ERLANG_VERSION $ERL_HOME
+if [[ ! -d $ASDF_DATA_DIR ]]; then
+  mkdir -p $ASDF_DATA_DIR
+  git clone https://github.com/asdf-vm/asdf.git $ASDF_DATA_DIR --branch v0.7.8
 fi
 
-. $ERL_HOME/activate
+source $ASDF_DATA_DIR/asdf.sh
+asdf update
 
-if ! kiex use $ELIXIR_VERSION; then
-    kiex install $ELIXIR_VERSION
-    kiex use $ELIXIR_VERSION
-fi
+asdf plugin-add erlang || true
+asdf plugin-add elixir || true
+asdf plugin-update erlang
+asdf plugin-update elixir
+
+asdf install
 
 mix local.hex --force
 mix local.rebar --force

--- a/test/tablespoon/communicator/modem_test.exs
+++ b/test/tablespoon/communicator/modem_test.exs
@@ -47,6 +47,16 @@ defmodule Tablespoon.Communicator.ModemTest do
       assert comm.transport.sent == ["AT*RELAYOUT4=1\n"]
     end
 
+    test "if connected to a picocom modem, does not connect until the debugging output is finished" do
+      comm = Modem.new(FakeTransport.new())
+      {:ok, comm, []} = Modem.connect(comm)
+      refute comm.connection_state == :connected
+      {:ok, comm, []} = process_data(comm, ["picocom v3.1\n\nOK\n"], [])
+      refute comm.connection_state == :connected
+      {:ok, comm, []} = process_data(comm, ["Terminal ready\n"], [])
+      assert comm.connection_state == :connected
+    end
+
     test "handles errors in the response" do
       query =
         Query.new(

--- a/test/tablespoon/intersection_test.exs
+++ b/test/tablespoon/intersection_test.exs
@@ -210,6 +210,23 @@ defmodule Tablespoon.IntersectionTest do
     end
   end
 
+  describe "handle_info(:reconnect)" do
+    @tag :capture_log
+    test "does not change the current connection status" do
+      {:ok, state, _} = Intersection.init(config: @config)
+      refute state.connected?
+
+      {:noreply, state, {:continue, :connect}} = Intersection.handle_info(:reconnect, state)
+      refute state.connected?
+
+      {:noreply, state, _} = Intersection.handle_continue(:connect, state)
+      assert state.connected?
+
+      {:noreply, state, {:continue, :connect}} = Intersection.handle_info(:reconnect, state)
+      assert state.connected?
+    end
+  end
+
   describe "handle_results/2" do
     setup :log_level_info
 

--- a/test/tablespoon/intersection_test.exs
+++ b/test/tablespoon/intersection_test.exs
@@ -134,7 +134,9 @@ defmodule Tablespoon.IntersectionTest do
 
       log =
         capture_log(fn ->
-          {:noreply, ^state} = Intersection.handle_cast({:query, query}, state)
+          {:noreply, state} = Intersection.handle_cast({:query, query}, state)
+          refute state.connected?
+          assert state.reconnect_ref
         end)
 
       assert log =~ "error=:not_connected"


### PR DESCRIPTION
This does not seem to trigger any issues with either the SSH or TCP
modems. By periodically (every 3 minutes in this case) sending a packet over
the connection, we should keep it open as well as detect disconnections.