### PR TITLE
feat(Modem): cancel requests in the background if we don't see one

### DIFF
--- a/lib/tablespoon/query.ex
+++ b/lib/tablespoon/query.ex
@@ -33,8 +33,7 @@ defmodule Tablespoon.Query do
   @doc "Create a new Query"
   @spec new(Keyword.t()) :: t
   def new(opts) do
-    opts = Map.new(opts)
-    opts = Map.put_new_lazy(opts, :received_at_mono, &System.monotonic_time/0)
+    opts = opts_as_map(opts)
     struct!(__MODULE__, opts)
   end
 
@@ -43,5 +42,17 @@ defmodule Tablespoon.Query do
   def processing_time(%__MODULE__{} = q, time_unit) do
     diff = System.monotonic_time() - q.received_at_mono
     System.convert_time_unit(diff, :native, time_unit)
+  end
+
+  @doc "Create a new Query based on an existing query, with some updates"
+  @spec update(t, Keyword.t()) :: t
+  def update(%__MODULE__{} = query, opts) do
+    opts = opts_as_map(opts)
+    struct!(query, opts)
+  end
+
+  defp opts_as_map(opts) do
+    opts = Map.new(opts)
+    Map.put_new_lazy(opts, :received_at_mono, &System.monotonic_time/0)
   end
 end


### PR DESCRIPTION
With the Modem protocol, we can only have the modem in one of two states:
on and off. If we get two requests and a cancel, we don't want the cancel to
take effect, as there's still a vehicle waiting to pass through the
intersection.

However, if that second vehicle doesn't send us a cancel message, we can get
stuck in the on position. This change addresses that, by keeping a queue of
vehicles who have requested that the intersection stay on. If a timeout
expires and the vehicle has not sent a cancel message, we'll do it in the
background and log a warning.