### PR TITLE
feat: support loading `runtime.exs` from an envvar

### DIFF
--- a/.github/workflows/deploy-ecs-prod.yml
+++ b/.github/workflows/deploy-ecs-prod.yml
@@ -10,15 +10,6 @@ jobs:
     concurrency: prod
     steps:
     - uses: actions/checkout@v2
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
-    - name: Fetch configuration
-      run: |
-        aws s3 cp s3://${{ secrets.CONFIG_BUCKET }}/tablespoon/prod.secret.exs config/prod.secret.exs
     - uses: mbta/actions/build-push-ecr@v1
       id: build-push
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,14 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
-
-    - name: Fetch configuration
-      run: |
-        aws s3 cp s3://${{ secrets.CONFIG_BUCKET }}/tablespoon/prod.secret.exs config/prod.secret.exs
     - run: docker build .

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -19,5 +19,3 @@ config :logger, :splunk,
   level: :info
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
-
-import_config "prod.secret.exs"

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -20,3 +20,8 @@ INSTANCE_ID=$(curl --max-time 5 -s http://169.254.169.254/latest/meta-data/insta
 
 export RELEASE_DISTRIBUTION=sname
 export RELEASE_NODE=tablespoon-$INSTANCE_ID
+
+# Write environment configuration (if configured)
+if [ -n "$CONFIG_RUNTIME_EXS" ]; then
+    echo "$CONFIG_RUNTIME_EXS" > "$RELEASE_ROOT/releases/$RELEASE_VSN/runtime.exs"
+fi


### PR DESCRIPTION
We need to be able to configure the intersections, as well as other
configuration, outside of this repo. Previously, this was split between a
`prod.secret.exs` which was loaded at compile time, and `INTERSECTIONS_JSON`
loaded at runtime.

Now, we provide a `CONFIG_RUNTIME_EXS` environment variable, which is written
to `runtime.exs` before the application starts and loaded as configuration. This provides us one
file/secret to configure.