### PR TITLE
Graceful shutdown

### DIFF
--- a/lib/tablespoon/communicator.ex
+++ b/lib/tablespoon/communicator.ex
@@ -15,6 +15,7 @@ defmodule Tablespoon.Communicator do
   @type result :: {:sent, Query.t()} | {:failed, Query.t(), error} | {:error, error}
   @callback new(Transport.t(), Keyword.t()) :: t
   @callback connect(t) :: {:ok, t, [result]} | {:error, error}
+  @callback close(t) :: {:ok, t, [result]}
   @callback send(t, Query.t()) :: {:ok, t, [result]} | {:error, error}
   @callback stream(t, term) :: {:ok, t, [result]} | :unknown
 
@@ -34,6 +35,11 @@ defmodule Tablespoon.Communicator do
   @spec connect(t) :: {:ok, t, [result]} | {:error, error}
   def connect(%{__struct__: module} = comm) do
     module.connect(comm)
+  end
+
+  @spec close(t) :: {:ok, t, [result]}
+  def close(%{__struct__: module} = comm) do
+    module.close(comm)
   end
 
   @spec send(t, Query.t()) :: {:ok, t, [result]} | {:error, error}

--- a/lib/tablespoon/transport.ex
+++ b/lib/tablespoon/transport.ex
@@ -9,6 +9,7 @@ defmodule Tablespoon.Transport do
 
   @callback new(Keyword.t()) :: t
   @callback connect(t) :: {:ok, t} | {:error, error}
+  @callback close(t) :: t
   @callback stream(t, term) :: {:ok, t, [result]} | {:error, error} | :unknown
   @callback send(t, iodata) :: {:ok, t} | {:error, error}
 
@@ -16,6 +17,12 @@ defmodule Tablespoon.Transport do
   @spec connect(t) :: {:ok, t} | {:error, error}
   def connect(struct) do
     struct.__struct__.connect(struct)
+  end
+
+  @doc "Call close/1 on the implementation struct"
+  @spec close(t) :: t
+  def close(struct) do
+    struct.__struct__.close(struct)
   end
 
   @doc "Call stream/2 on the implementation struct"

--- a/lib/tablespoon/transport/fake_btd.ex
+++ b/lib/tablespoon/transport/fake_btd.ex
@@ -35,6 +35,11 @@ defmodule Tablespoon.Transport.FakeBtd do
   end
 
   @impl Tablespoon.Transport
+  def close(%__MODULE__{} = t) do
+    %{t | ref: nil}
+  end
+
+  @impl Tablespoon.Transport
   def send(%__MODULE__{ref: nil}, _data) do
     {:error, :not_connected}
   end

--- a/lib/tablespoon/transport/fake_modem.ex
+++ b/lib/tablespoon/transport/fake_modem.ex
@@ -43,6 +43,11 @@ defmodule Tablespoon.Transport.FakeModem do
   end
 
   @impl Tablespoon.Transport
+  def close(%__MODULE__{} = t) do
+    %{t | ref: nil, buffer: ""}
+  end
+
+  @impl Tablespoon.Transport
   def send(%__MODULE__{ref: nil}, _) do
     {:error, :not_connected}
   end

--- a/lib/tablespoon/transport/pmpp_multiplex.ex
+++ b/lib/tablespoon/transport/pmpp_multiplex.ex
@@ -32,6 +32,12 @@ defmodule Tablespoon.Transport.PMPPMultiplex do
   end
 
   @impl Tablespoon.Transport
+  def close(%__MODULE__{from: from} = t) when from != nil do
+    _ = __MODULE__.Child.close(from)
+    %{t | from: nil}
+  end
+
+  @impl Tablespoon.Transport
   def send(%__MODULE__{from: from} = t, iodata) when from != nil do
     with :ok <- __MODULE__.Child.send(from, iodata) do
       {:ok, t}

--- a/lib/tablespoon/transport/pmpp_multiplex/child.ex
+++ b/lib/tablespoon/transport/pmpp_multiplex/child.ex
@@ -22,6 +22,10 @@ defmodule Tablespoon.Transport.PMPPMultiplex.Child do
     GenServer.start_link(__MODULE__, parent, name: name)
   end
 
+  def close({pid, _ref}) do
+    GenServer.call(pid, :close)
+  end
+
   def send({pid, ref}, iodata) do
     GenServer.call(pid, {:send, {self(), ref}, iodata})
   end
@@ -49,6 +53,11 @@ defmodule Tablespoon.Transport.PMPPMultiplex.Child do
   end
 
   @impl GenServer
+  def handle_call(:close, _from, state) do
+    transport = Transport.close(state.transport)
+    {:stop, :normal, %{state | transport: transport}}
+  end
+
   def handle_call({:send, key, iodata}, _from, state) do
     case do_send(key, iodata, state) do
       {:ok, state} ->

--- a/lib/tablespoon/transport/ssh.ex
+++ b/lib/tablespoon/transport/ssh.ex
@@ -81,6 +81,12 @@ defmodule Tablespoon.Transport.SSH do
   end
 
   @impl Tablespoon.Transport
+  def close(%__MODULE__{} = ssh) do
+    {:ok, ssh, _} = do_close(ssh)
+    ssh
+  end
+
+  @impl Tablespoon.Transport
   def stream(
         %__MODULE__{conn_ref: conn_ref, channel_id: channel_id} = ssh,
         {:ssh_cm, conn_ref, {:data, channel_id, 0, data}}

--- a/test/support/fake_transport.ex
+++ b/test/support/fake_transport.ex
@@ -1,7 +1,7 @@
 defmodule Tablespoon.Transport.Fake do
   @moduledoc false
   @behaviour Tablespoon.Transport
-  defstruct connect_count: 0, sent: []
+  defstruct connect_count: 0, close_count: 0, sent: [], open?: false
 
   @impl Tablespoon.Transport
   def new(_opts \\ []) do
@@ -10,7 +10,12 @@ defmodule Tablespoon.Transport.Fake do
 
   @impl Tablespoon.Transport
   def connect(fake) do
-    {:ok, %{fake | connect_count: fake.connect_count + 1}}
+    {:ok, %{fake | connect_count: fake.connect_count + 1, open?: true}}
+  end
+
+  @impl Tablespoon.Transport
+  def close(fake) do
+    %{fake | open?: false}
   end
 
   @impl Tablespoon.Transport

--- a/test/tablespoon/transport/pmpp_multiplex_test.exs
+++ b/test/tablespoon/transport/pmpp_multiplex_test.exs
@@ -184,6 +184,11 @@ defmodule Echo do
   end
 
   @impl Tablespoon.Transport
+  def close(%__MODULE__{} = t) do
+    {:ok, %{t | ref: nil}}
+  end
+
+  @impl Tablespoon.Transport
   def send(%__MODULE__{ref: ref} = t, iodata) when is_reference(ref) do
     binary = IO.iodata_to_binary(iodata)
 

--- a/test/tablespoon/transport/tcp_test.exs
+++ b/test/tablespoon/transport/tcp_test.exs
@@ -66,6 +66,16 @@ defmodule Tablespoon.Transport.TCPTest do
     end
   end
 
+  describe "close/1" do
+    test "closes the TCP connection", %{listener: listener, listener_port: listener_port} do
+      {:ok, tcp} = TCP.connect(TCP.new(host: @localhost, port: listener_port))
+      {:ok, accept} = :gen_tcp.accept(listener)
+      tcp = TCP.close(tcp)
+      refute tcp.socket
+      assert_receive {:tcp_closed, ^accept}
+    end
+  end
+
   describe "error states" do
     test "the connection is closed if the owning process stops", %{
       listener: listener,


### PR DESCRIPTION
- log failed queries if we shut down before the responses come in
- send cancellation queries to intersections if we're shutting down with an open request