### PR TITLE
fix(Intersection): use local time when checking warning times

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,6 +27,9 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Use tzdata for time zone info
+config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
+
 intersections =
   case File.read("priv/intersections.json") do
     {:ok, data} -> data
@@ -40,7 +43,8 @@ config :tablespoon,
     {:standard, 5, 300_000},
     # reset the fuse after 60 seconds
     {:reset, 60_000}
-  }
+  },
+  time_zone: "America/New_York"
 
 # connection configuration for the different types of Communicators
 config :tablespoon, Tablespoon.Communicator.Btd,

--- a/lib/tablespoon/intersection.ex
+++ b/lib/tablespoon/intersection.ex
@@ -78,7 +78,7 @@ defmodule Tablespoon.Intersection do
     :reconnect_ref,
     connected?: false,
     connect_failure_count: 0,
-    time_fn: &:erlang.time/0
+    time_fn: &__MODULE__.local_time/0
   ]
 
   @typep t :: %__MODULE__{
@@ -337,6 +337,16 @@ defmodule Tablespoon.Intersection do
 
   def retry_after(_connect_failure_count) do
     @max_reconnect_timeout
+  end
+
+  @doc """
+  A {hour, minute, second} tuple in the local timezone.
+  """
+  @spec local_time() :: :calendar.time()
+  @spec local_time(Calendar.time_zone()) :: :calendar.time()
+  def local_time(time_zone \\ Application.fetch_env!(:tablespoon, :time_zone)) do
+    now = DateTime.now!(time_zone)
+    {now.hour, now.minute, now.second}
   end
 
   defp state_no_reply(%{config: %{warning_timeout_ms: timeout}, connected?: true} = state) do

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,8 @@ defmodule Tablespoon.MixProject do
       {:logster, "~> 1.0"},
       {:ehmon, github: "mbta/ehmon", branch: "master", only: [:prod]},
       {:fuse, "~> 2.5.0"},
-      {:ranch, "~> 1.7.1"}
+      {:ranch, "~> 1.7.1"},
+      {:tzdata, "~> 1.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -33,5 +33,6 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
+  "tzdata": {:hex, :tzdata, "1.1.0", "72f5babaa9390d0f131465c8702fa76da0919e37ba32baa90d93c583301a8359", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "18f453739b48d3dc5bcf0e8906d2dc112bb40baafe2c707596d89f3c8dd14034"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/tablespoon/intersection_test.exs
+++ b/test/tablespoon/intersection_test.exs
@@ -366,6 +366,15 @@ defmodule Tablespoon.IntersectionTest do
     end
   end
 
+  describe "local_time/0" do
+    test "returns {hour, minute, second} tuple in the given timezone" do
+      time_zone = "America/Los_Angeles"
+      now = DateTime.now!(time_zone)
+      {hour, minute, second} = Intersection.local_time(time_zone)
+      assert Time.diff(Time.new!(hour, minute, second), now) <= 1
+    end
+  end
+
   defp log_level_info(_) do
     log_level = Logger.level()
 


### PR DESCRIPTION
The warning times in `Config` are defined in local time, but Tablespoon is
not necessarily running in an environment when the server time is the same as
local time. Instead, we configure the correct local time zone, and use that
when generating the time tuple.