### PR TITLE
fix(Modem): close the transport on stale messages

### DIFF
--- a/lib/tablespoon/communicator/modem.ex
+++ b/lib/tablespoon/communicator/modem.ex
@@ -101,8 +101,7 @@ defmodule Tablespoon.Communicator.Modem do
         end
       end)
 
-    transport = Transport.close(comm.transport)
-    do_close(%{comm | transport: transport}, :close, [])
+    do_close(comm, :close, [])
   end
 
   @impl Tablespoon.Communicator
@@ -422,7 +421,9 @@ defmodule Tablespoon.Communicator.Modem do
         _ = Process.cancel_timer(ref)
       end
 
-    comm = %__MODULE__{transport: comm.transport, expect_ok?: comm.expect_ok?}
+    transport = Transport.close(comm.transport)
+
+    comm = %__MODULE__{transport: transport, expect_ok?: comm.expect_ok?}
     {:ok, comm, events ++ failures ++ tail_events}
   end
 end

--- a/test/tablespoon/communicator/modem_test.exs
+++ b/test/tablespoon/communicator/modem_test.exs
@@ -238,6 +238,7 @@ defmodule Tablespoon.Communicator.ModemTest do
       {:ok, comm, events} = Modem.send(comm, query)
       {:ok, comm, events} = process_data(comm, [{comm.id_ref, :timeout}], events)
       assert events == [{:failed, query, :stale}, {:error, :stale}]
+      refute comm.transport.open?
       assert comm.transport.sent == ["AT*RELAYOUT4=0\n"]
     end
 


### PR DESCRIPTION
Previously, we wouldn't disconnect the transport when dealing with stale
messages. This would mean that the transport is in an unepxected state
when we re-connect after the stale message, resulting in crashes.