### PR TITLE
feat: ignore duplicate messages

### DIFF
--- a/lib/tablespoon/duplicates.ex
+++ b/lib/tablespoon/duplicates.ex
@@ -1,0 +1,62 @@
+defmodule Tablespoon.Duplicates do
+  @moduledoc """
+  Detect duplicate message IDs with a rolling timespan.
+  """
+  @enforce_keys [:tid]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          tid: :ets.tid()
+        }
+
+  @spec new :: t()
+  def new do
+    %__MODULE__{
+      tid: :ets.new(:duplicates, [:set, :public, {:read_concurrency, true}])
+    }
+  end
+
+  @doc """
+  Returns a boolean indicating whether we've seen the given term before.
+
+  If not, store the term and the time we saw it.
+
+  ## Examples
+
+      iex> dup = Tablespoon.Duplicates.new()
+      iex> Tablespoon.Duplicates.seen?(dup, 1, 1)
+      false
+      iex> Tablespoon.Duplicates.seen?(dup, 2, 2)
+      false
+      iex> Tablespoon.Duplicates.seen?(dup, 1, 3)
+      true
+  """
+  @spec seen?(t(), term(), integer()) :: boolean
+  def seen?(dups, term, seen_at)
+
+  def seen?(%__MODULE__{tid: tid}, term, seen_at) do
+    :ets.insert_new(tid, {term, seen_at}) == false
+  end
+
+  @doc """
+  Expire terms seen before the given timestamp.
+
+  ## Example
+
+      iex> dup = Tablespoon.Duplicates.new()
+      iex> Tablespoon.Duplicates.seen?(dup, 1, 0)
+      false
+      iex> Tablespoon.Duplicates.expire(dup, 1)
+      :ok
+      iex> Tablespoon.Duplicates.seen?(dup, 1, 2)
+      false
+  """
+  @spec expire(t(), integer()) :: :ok
+  def expire(dup, seen_before)
+
+  def expire(%__MODULE__{tid: tid}, seen_before) do
+    :ets.select_delete(tid, [{{:_, :"$1"}, [{:<, :"$1", seen_before}], [true]}])
+
+    :ok
+  end
+end

--- a/lib/tablespoon/intersection/duplicates.ex
+++ b/lib/tablespoon/intersection/duplicates.ex
@@ -1,0 +1,45 @@
+defmodule Tablespoon.Intersection.Duplicates do
+  @moduledoc """
+  Wrapper around Tablespoon.Duplicates, which maintains a global duplicate table.
+  """
+  require Logger
+  use GenServer
+
+  alias Tablespoon.{Duplicates, Query}
+
+  @term_key __MODULE__
+
+  # how often to scan for / clear duplicate message cache: 30m
+  @scan_frequency 30 * 60_000
+
+  def start_link(opts) do
+    scan_frequency = Keyword.get(opts, :scan_frequency, @scan_frequency)
+    GenServer.start_link(__MODULE__, scan_frequency)
+  end
+
+  @spec seen?(Query.t()) :: boolean
+  def seen?(q) do
+    case :persistent_term.get(@term_key) do
+      %Duplicates{} = dups ->
+        key = {q.intersection_alias, q.type, q.id}
+        Duplicates.seen?(dups, key, q.received_at_mono)
+
+      nil ->
+        false
+    end
+  end
+
+  @impl GenServer
+  def init(scan_frequency) do
+    dups = Duplicates.new()
+    :persistent_term.put(__MODULE__, dups)
+    {:ok, {dups, scan_frequency}, scan_frequency}
+  end
+
+  @impl GenServer
+  def handle_info(:timeout, {dups, scan_frequency} = state) do
+    Logger.info("#{__MODULE__} clearing duplicate message cache after #{scan_frequency}ms")
+    Duplicates.expire(dups, System.monotonic_time() - scan_frequency)
+    {:noreply, state, scan_frequency}
+  end
+end

--- a/lib/tablespoon/intersection/super_supervisor.ex
+++ b/lib/tablespoon/intersection/super_supervisor.ex
@@ -11,6 +11,7 @@ defmodule Tablespoon.Intersection.SuperSupervisor do
   def init(configs) do
     Supervisor.init(
       [
+        Tablespoon.Intersection.Duplicates,
         {Registry, name: Tablespoon.Intersection.registry(), keys: :unique},
         {Tablespoon.Intersection.Supervisor, configs}
       ],

--- a/test/tablespoon/intersection/duplicates_test.exs
+++ b/test/tablespoon/intersection/duplicates_test.exs
@@ -1,0 +1,43 @@
+defmodule Tablespoon.Intersection.DuplicatesTest do
+  use ExUnit.Case
+
+  alias Tablespoon.Intersection.Duplicates
+  alias Tablespoon.Query
+
+  describe "seen?" do
+    test "returns true after it has seen the query" do
+      {:ok, _pid} = Duplicates.start_link([])
+
+      query =
+        Query.new(
+          id: "id",
+          type: :request,
+          intersection_alias: "alias",
+          vehicle_id: "1234",
+          approach: :north,
+          event_time: System.system_time()
+        )
+
+      refute Duplicates.seen?(query)
+      assert Duplicates.seen?(query)
+    end
+
+    test "returns false after the duplicates are expired" do
+      {:ok, _pid} = Duplicates.start_link(scan_frequency: 0)
+
+      query =
+        Query.new(
+          id: "id",
+          type: :request,
+          intersection_alias: "alias",
+          vehicle_id: "1234",
+          approach: :north,
+          event_time: System.system_time()
+        )
+
+      refute Duplicates.seen?(query)
+      Process.sleep(1)
+      refute Duplicates.seen?(query)
+    end
+  end
+end


### PR DESCRIPTION
We maintain a global ETS table of seen `{intersection, type, query ID}`
tuples, and use that to skip query messages we've already processed.