### PR TITLE
chore: upgrade GitHub Actions versions to v3

### DIFF
--- a/.github/workflows/deploy-ecs-prod.yml
+++ b/.github/workflows/deploy-ecs-prod.yml
@@ -9,7 +9,7 @@ jobs:
     environment: prod
     concurrency: prod
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: mbta/actions/build-push-ecr@v1
       id: build-push
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,5 +7,5 @@ jobs:
     name: Build Docker image
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: docker build .

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: asdf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
@@ -40,7 +40,7 @@ jobs:
       - uses: mbta/actions/reshim-asdf@v1
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
           key: ${{ runner.os }}-mix-v2-${{ hashFiles('**/mix.lock') }}
@@ -61,7 +61,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
         if: github.event.pull_request
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: elixir-lcov
           path: cover/

--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -43,7 +43,7 @@ jobs:
           unzip elixir-lcov.zip
           echo "PR_SHA=$(cat PR_SHA)" >> $GITHUB_ENV
           echo "PR_NUMBER=$(cat PR_NUMBER)" >> $GITHUB_ENV
-      - uses: actions/checkout@v2 # UNTRUSTED CODE - do not run scripts from it
+      - uses: actions/checkout@v3 # UNTRUSTED CODE - do not run scripts from it
         with:
           ref: ${{ env.PR_SHA }}
       - name: Upload coverage artifact and post comment


### PR DESCRIPTION
This should avoid using deprecated functionality, but without any other visible changes.