### PR TITLE
Chore: Update GitHub actions to use assumed role

### DIFF
--- a/.github/workflows/deploy-ecs-prod.yml
+++ b/.github/workflows/deploy-ecs-prod.yml
@@ -6,20 +6,21 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment: prod
     concurrency: prod
     steps:
     - uses: actions/checkout@v3
-    - uses: mbta/actions/build-push-ecr@v1
+    - uses: mbta/actions/build-push-ecr@v2
       id: build-push
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         docker-repo: ${{ secrets.DOCKER_REPO }}
-    - uses: mbta/actions/deploy-ecs@v1
+    - uses: mbta/actions/deploy-ecs@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         ecs-cluster: tablespoon
         ecs-service: tablespoon-prod
         docker-tag: ${{ steps.build-push.outputs.docker-tag }}

--- a/.github/workflows/prod-stunnel.yml
+++ b/.github/workflows/prod-stunnel.yml
@@ -7,6 +7,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     concurrency: prod-linux
     env:
       ECS_CLUSTER: linux-prod
@@ -14,10 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: mbta/actions/deploy-ecs@v1
+      - uses: mbta/actions/deploy-ecs@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}
           ecs-service: ${{ env.ECS_SERVICE }}
           docker-tag: ghcr.io/mbta/stunnel:5.71-r0-alpine-3.18.3


### PR DESCRIPTION
This PR updates the deploy workflow to use v2 of the shared `build-push-ecr` and `deploy-ecs` actions. These updated actions assume an IAM role instead of relying on long-lasting AWS keys for an IAM user