### PR TITLE
deps: pin trivy-action version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: docker build -t tablespoon .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: tablespoon
           trivy-config: trivy.yml

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in fs mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
Asana Task: [Trivy after-action followups](https://app.asana.com/1/15492006741476/project/1113179098808463/task/1213749140444703)

Caches have been cleared.
This pins `trivy-action` to the recommended version from https://redirect.github.com/aquasecurity/trivy/discussions/10425